### PR TITLE
This or that decision process

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,18 +1,24 @@
-import { Link } from "expo-router";
+import { Link, useRouter } from "expo-router";
 import { StyleSheet, Text, View } from "react-native";
 import apiClient from "../../utils/api-client";
 import { useSocket } from "@/contexts/SocketContext";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useEffect, useState } from "react";
 
 export default function Index() {
+  const router = useRouter();
   const { colours } = useTheme();
   const socket = useSocket();
   socket.emit("hi", "hi");
 
-  apiClient
-    .get("/")
-    .then(({ data }) => console.log(data))
-    .catch(() => console.log("Server not online!"));
+  useEffect(() => {
+    apiClient
+      .get("/")
+      .then(({ data }) => console.log(data))
+      .catch(() => {
+        router.push("/NotConnectedToServer");
+      });
+  }, []);
 
   return (
     <View style={[styles.container, { backgroundColor: colours.primary }]}>

--- a/app/Decision.tsx
+++ b/app/Decision.tsx
@@ -1,25 +1,42 @@
-import ThisOrThat from "@/components/decision-processes/ThisOrThat";
 import apiClient from "@/utils/api-client";
 import { useLocalSearchParams } from "expo-router";
+import { DecisionProps } from "../utils/props";
 import { useEffect, useState } from "react";
+import ThisOrThat from "@/components/decision-processes/ThisOrThat";
+import { Text } from "react-native";
 
 export default function Decision() {
-  const processIds = {
+  const processIds: Record<string, string> = {
     ["6784d7a5844f23ac9810cf50"]: "ThisOrThat",
   };
   const { decision_id } = useLocalSearchParams();
-  const [decisionData, setDecisionData] = useState();
+
+  const [decisionData, setDecisionData] = useState<DecisionProps | undefined>(
+    undefined
+  );
 
   useEffect(() => {
-    apiClient
-      .get(`/decisions/${decision_id}`)
-      .then(({ data }) => {
-        setDecisionData(data);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
+    if (decision_id) {
+      apiClient
+        .get(`/decisions/${decision_id}`)
+        .then(({ data }) => {
+          setDecisionData(data);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    }
   }, [decision_id]);
 
-  return <ThisOrThat></ThisOrThat>;
+  if (!decisionData) {
+    return null;
+  }
+
+  return processIds[decisionData.decisionsProcess_id] === "ThisOrThat" ? (
+    <ThisOrThat />
+  ) : (
+    <Text>
+      Decision process does not exist yet! Come back for future updates
+    </Text>
+  );
 }

--- a/app/Decision.tsx
+++ b/app/Decision.tsx
@@ -33,7 +33,7 @@ export default function Decision() {
   }
 
   return processIds[decisionData.decisionsProcess_id] === "ThisOrThat" ? (
-    <ThisOrThat />
+    <ThisOrThat decisionData={decisionData} setDecisionData={setDecisionData} />
   ) : (
     <Text>
       Decision process does not exist yet! Come back for future updates

--- a/app/Decision.tsx
+++ b/app/Decision.tsx
@@ -3,9 +3,11 @@ import { useLocalSearchParams } from "expo-router";
 import { DecisionProps } from "../utils/props";
 import { useEffect, useState } from "react";
 import ThisOrThat from "@/components/decision-processes/ThisOrThat";
-import { Text } from "react-native";
+import { Text, View } from "react-native";
 
 export default function Decision() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [errMsg, setErrMsg] = useState("");
   const processIds: Record<string, string> = {
     ["6784d7a5844f23ac9810cf50"]: "ThisOrThat",
   };
@@ -16,15 +18,21 @@ export default function Decision() {
   );
 
   useEffect(() => {
+    setErrMsg("");
     if (decision_id) {
+      setIsLoading(true);
       apiClient
         .get(`/decisions/${decision_id}`)
         .then(({ data }) => {
           setDecisionData(data);
+          setIsLoading(false);
         })
         .catch((err) => {
-          console.log(err);
+          setErrMsg("error loading decision");
+          setIsLoading(false);
         });
+    } else {
+      setErrMsg("error loading decision");
     }
   }, [decision_id]);
 
@@ -32,7 +40,11 @@ export default function Decision() {
     return null;
   }
 
-  return processIds[decisionData.decisionsProcess_id] === "ThisOrThat" ? (
+  return isLoading ? (
+    <Text>"loading decision..."</Text>
+  ) : errMsg ? (
+    <Text>{errMsg}</Text>
+  ) : processIds[decisionData.decisionsProcess_id] === "ThisOrThat" ? (
     <ThisOrThat decisionData={decisionData} setDecisionData={setDecisionData} />
   ) : (
     <Text>

--- a/app/Decision.tsx
+++ b/app/Decision.tsx
@@ -1,0 +1,25 @@
+import ThisOrThat from "@/components/decision-processes/ThisOrThat";
+import apiClient from "@/utils/api-client";
+import { useLocalSearchParams } from "expo-router";
+import { useEffect, useState } from "react";
+
+export default function Decision() {
+  const processIds = {
+    ["6784d7a5844f23ac9810cf50"]: "ThisOrThat",
+  };
+  const { decision_id } = useLocalSearchParams();
+  const [decisionData, setDecisionData] = useState();
+
+  useEffect(() => {
+    apiClient
+      .get(`/decisions/${decision_id}`)
+      .then(({ data }) => {
+        setDecisionData(data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [decision_id]);
+
+  return <ThisOrThat></ThisOrThat>;
+}

--- a/app/Decision.tsx
+++ b/app/Decision.tsx
@@ -3,15 +3,25 @@ import { useLocalSearchParams } from "expo-router";
 import { DecisionProps } from "../utils/props";
 import { useEffect, useState } from "react";
 import ThisOrThat from "@/components/decision-processes/ThisOrThat";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
+import { useSocket } from "@/contexts/SocketContext";
 
 export default function Decision() {
+  const socket = useSocket();
+
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [decisionMsg, setDecisionMsg] = useState("");
+
+  const { decision_id } = useLocalSearchParams();
+  useEffect(() => {
+    socket.emit("decision", decision_id);
+  }, [decision_id]);
+
   const [isLoading, setIsLoading] = useState(true);
   const [errMsg, setErrMsg] = useState("");
   const processIds: Record<string, string> = {
     ["6784d7a5844f23ac9810cf50"]: "ThisOrThat",
   };
-  const { decision_id } = useLocalSearchParams();
 
   const [decisionData, setDecisionData] = useState<DecisionProps | undefined>(
     undefined
@@ -28,13 +38,19 @@ export default function Decision() {
           setIsLoading(false);
         })
         .catch((err) => {
+          console.log(err);
           setErrMsg("error loading decision");
           setIsLoading(false);
         });
     } else {
       setErrMsg("error loading decision");
     }
-  }, [decision_id]);
+  }, [decision_id, refreshKey]);
+
+  socket.on("refresh", (msg) => {
+    setRefreshKey((key) => key + 1);
+    setDecisionMsg(msg);
+  });
 
   if (!decisionData) {
     return null;
@@ -45,7 +61,11 @@ export default function Decision() {
   ) : errMsg ? (
     <Text>{errMsg}</Text>
   ) : processIds[decisionData.decisionsProcess_id] === "ThisOrThat" ? (
-    <ThisOrThat decisionData={decisionData} setDecisionData={setDecisionData} />
+    <ThisOrThat
+      decisionData={decisionData}
+      setDecisionData={setDecisionData}
+      decisionMsg={decisionMsg}
+    />
   ) : (
     <Text>
       Decision process does not exist yet! Come back for future updates

--- a/app/NotConnectedToServer.tsx
+++ b/app/NotConnectedToServer.tsx
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export default function NotConnectedToServer() {
+  return <Text> WARNING: NOT CONNECTED TO SERVER</Text>;
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ export default function RootLayout() {
             <Stack>
               <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
               <Stack.Screen name="User" />
+              <Stack.Screen name="Decision" />
               <Stack.Screen name="+not-found" />
             </Stack>
           </ThemeProvider>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,8 +68,18 @@ export default function Header() {
                 />
               }
             >
-              <MenuOption onSelect={() => {}}>
-                <Text>Sparkle Unicorn invited you to make a decision</Text>
+              <MenuOption
+                onSelect={() => {
+                  setIsNotificationDropdownVisible(false);
+                  router.push({
+                    pathname: "/Decision",
+                    params: { decision_id: "678940615a51bf4a2ed681c0" },
+                  });
+                }}
+              >
+                <Text>
+                  You have a pending decision - click here to continue
+                </Text>
               </MenuOption>
               <MenuOption onSelect={() => {}}>
                 <Text>Decision completed: view decision history</Text>

--- a/components/StartDecisionButton.tsx
+++ b/components/StartDecisionButton.tsx
@@ -1,0 +1,53 @@
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+type Props = {
+  onPress: () => void;
+  text: string;
+};
+
+export const StartDecisionButton = ({ onPress, text }: Props) => {
+  const { colours } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[
+          styles.button,
+          {
+            backgroundColor: colours.surface.disabled,
+            borderColor: colours.surface.primary,
+          },
+        ]}
+        onPress={onPress}
+      >
+        <Ionicons name="play-outline" size={24} color={colours.text.disabled} />
+        <Text style={[styles.text, { color: colours.text.disabled }]}>
+          {text}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "column",
+  },
+  button: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 2,
+    paddingHorizontal: 12,
+    paddingVertical: 36,
+    borderRadius: 8,
+    marginVertical: 5,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: "bold",
+    marginLeft: 8,
+  },
+});

--- a/components/ThisOrThatButton.tsx
+++ b/components/ThisOrThatButton.tsx
@@ -1,0 +1,74 @@
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
+
+type Props = {
+  onPress: (arg0: number) => void;
+  text: string;
+  image_url?: string;
+  thisOrThat: 0 | 1;
+};
+
+export const ThisOrThatButton = ({
+  onPress,
+  text,
+  image_url,
+  thisOrThat,
+}: Props) => {
+  const { colours } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[
+          styles.button,
+          {
+            backgroundColor: colours.surface.disabled,
+            borderColor: colours.surface.primary,
+          },
+        ]}
+        onPress={() => {
+          return onPress(thisOrThat);
+        }}
+      >
+        <Image
+          source={{
+            uri: image_url,
+          }}
+          style={styles.tileImage}
+        />
+        <Text style={[styles.text, { color: colours.text.disabled }]}>
+          {text}
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "column",
+  },
+  button: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 2,
+    paddingHorizontal: 12,
+    paddingVertical: 36,
+    borderRadius: 8,
+    marginVertical: 5,
+  },
+  text: {
+    fontSize: 16,
+    fontWeight: "bold",
+    marginLeft: 8,
+  },
+  tileImage: {
+    marginTop: 10,
+    margin: 10,
+    marginBottom: 0,
+    width: 60,
+    height: 60,
+    borderRadius: 10,
+  },
+});

--- a/components/decision-processes/ThisOrThat.tsx
+++ b/components/decision-processes/ThisOrThat.tsx
@@ -1,0 +1,5 @@
+import { Text } from "react-native";
+
+export default function ThisOrThat() {
+  return <Text>testing</Text>;
+}

--- a/components/decision-processes/ThisOrThat.tsx
+++ b/components/decision-processes/ThisOrThat.tsx
@@ -5,6 +5,7 @@ import apiClient from "@/utils/api-client";
 import { useState } from "react";
 import shuffleArray from "../../utils/shuffleArray";
 import getTwoRandomElements from "../../utils/getTwoRandomElements";
+import { ThisOrThatButton } from "../ThisOrThatButton";
 
 type Props = {
   decisionData: DecisionProps;
@@ -49,6 +50,61 @@ export default function ThisOrThat({ decisionData, setDecisionData }: Props) {
         console.log(err);
       });
   };
+
+  const handleChoice = (thisOrThat: number) => {
+    const flip = thisOrThat === 1 ? 0 : 1;
+    const newRemainingOptions = decisionData.saveData.remainingOptions.filter(
+      (remainingOption) => {
+        return (
+          remainingOption._id !== decisionData.saveData.currentOptions[flip]._id
+        );
+      }
+    );
+    const newVoteHistory = [
+      ...decisionData.saveData.voteHistory,
+      decisionData.saveData.currentOptions[thisOrThat],
+    ];
+    const newTurnNumber = decisionData.saveData.turnNumber + 1;
+    if (newRemainingOptions.length === 1)
+      apiClient
+        .put(`decisions/${decisionData._id}`, {
+          votingStatus: "completed",
+          saveData: {
+            turnNumber: null,
+            playerOrder: null,
+            remainingOptions: newRemainingOptions,
+            currentOptions: null,
+            voteHistory: newVoteHistory,
+          },
+          outcome: newRemainingOptions[0],
+        })
+        .then(({ data }) => {
+          console.log(data);
+          setDecisionData(data);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    else {
+      const newCurrentOptions = getTwoRandomElements(newRemainingOptions);
+      apiClient
+        .put(`decisions/${decisionData._id}`, {
+          saveData: {
+            turnNumber: newTurnNumber,
+            remainingOptions: newRemainingOptions,
+            currentOptions: newCurrentOptions,
+            voteHistory: newVoteHistory,
+          },
+        })
+        .then(({ data }) => {
+          setDecisionData(data);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    }
+  };
+
   return isStartingDecision ? (
     <Text>starting decision...</Text>
   ) : startDecisionErrMsg ? (
@@ -64,7 +120,24 @@ export default function ThisOrThat({ decisionData, setDecisionData }: Props) {
         </View>
       ) : decisionData.votingStatus === "in progress" ? (
         <View style={styles.decisionProcessContainer}>
-          <Text>you started the decision!</Text>
+          <Text>CHOOOOOSE</Text>
+          <ThisOrThatButton
+            onPress={handleChoice}
+            thisOrThat={0}
+            text={decisionData.saveData.currentOptions[0].name}
+            image_url={decisionData.saveData.currentOptions[0].image_url}
+          />
+          <ThisOrThatButton
+            onPress={handleChoice}
+            thisOrThat={1}
+            text={decisionData.saveData.currentOptions[1].name}
+            image_url={decisionData.saveData.currentOptions[1].image_url}
+          />
+        </View>
+      ) : decisionData.votingStatus === "completed" ? (
+        <View>
+          <Text>AND YOUR DECISION IS.........</Text>
+          <Text>{decisionData.saveData.remainingOptions[0].name}</Text>
         </View>
       ) : null}
     </View>

--- a/components/decision-processes/ThisOrThat.tsx
+++ b/components/decision-processes/ThisOrThat.tsx
@@ -1,5 +1,61 @@
-import { Text } from "react-native";
+import { DecisionProps } from "@/utils/props";
+import { StyleSheet, Text, View } from "react-native";
+import { StartDecisionButton } from "../StartDecisionButton";
+import apiClient from "@/utils/api-client";
 
-export default function ThisOrThat() {
-  return <Text>testing</Text>;
+type Props = {
+  decisionData: DecisionProps;
+  setDecisionData: React.Dispatch<
+    React.SetStateAction<DecisionProps | undefined>
+  >;
+};
+
+export default function ThisOrThat({ decisionData, setDecisionData }: Props) {
+  const handleStartDecision = () => {
+    apiClient
+      .put(`decisions/${decisionData._id}`, {
+        votingStatus: "in progress",
+      })
+      .then(({ data }) => {
+        setDecisionData((decisionData) => {
+          if (decisionData)
+            return { ...decisionData, votingStatus: "in progress" };
+        });
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+  return (
+    <View style={styles.container}>
+      {decisionData.votingStatus === "not started" ? (
+        <View style={styles.startDecisionContainer}>
+          <StartDecisionButton
+            onPress={handleStartDecision}
+            text="start decision"
+          />
+        </View>
+      ) : decisionData.votingStatus === "in progress" ? (
+        <View style={styles.decisionProcessContainer}>
+          <Text>you started the decision!</Text>
+        </View>
+      ) : null}
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  startDecisionContainer: {
+    justifyContent: "center",
+    marginBottom: 15,
+    marginHorizontal: 15,
+  },
+  decisionProcessContainer: {
+    justifyContent: "center",
+    marginBottom: 15,
+    marginHorizontal: 15,
+  },
+});

--- a/ip.js
+++ b/ip.js
@@ -1,1 +1,1 @@
-module.exports = "127.0.0.1";
+module.exports = "192.168.0.18";

--- a/utils/getTwoRandomElements.js
+++ b/utils/getTwoRandomElements.js
@@ -1,0 +1,14 @@
+export default function getTwoRandomElements(array) {
+  if (array.length < 2) {
+    throw new Error("The array must have at least two elements.");
+  }
+
+  const firstIndex = Math.floor(Math.random() * array.length);
+  let secondIndex;
+
+  do {
+    secondIndex = Math.floor(Math.random() * array.length);
+  } while (secondIndex === firstIndex);
+
+  return [array[firstIndex], array[secondIndex]];
+}

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -1,11 +1,11 @@
 export interface OptionProps {
   _id: string | null;
-  name: string | null;
+  name: string;
   description: string | null;
   customFields: string[];
   owner: string | null;
   createdAt: string | null;
-  image_url?: string | null;
+  image_url?: string;
   __v: number | null;
 }
 export interface ListProps {
@@ -26,17 +26,25 @@ export interface GroupProps {
   owner: string[];
   members: string[];
 }
+export interface SaveDataThisOrThatProps {
+  turnNumber: number;
+  turnOrder: UserProps[];
+  remainingOptions: OptionProps[];
+  currentOptions: [OptionProps, OptionProps];
+  voteHistory: OptionProps[];
+}
 export interface DecisionProps {
   _id: string | null;
   votingStatus: string | null;
   decisionsProcess_id: string;
   completedAt: string | null;
-  outcome: string | null;
+  outcome: OptionProps | null;
   __v: number | null;
   createdAt: string | null;
   updatedAt: string | null;
   group: GroupProps | null;
   list: ListProps | null;
+  saveData: SaveDataThisOrThatProps;
 }
 export interface UserProps {
   _id: string | null;

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -28,7 +28,7 @@ export interface GroupProps {
 }
 export interface SaveDataThisOrThatProps {
   turnNumber: number;
-  turnOrder: UserProps[];
+  playerOrder: UserProps[];
   remainingOptions: OptionProps[];
   currentOptions: [OptionProps, OptionProps];
   voteHistory: OptionProps[];

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -35,6 +35,8 @@ export interface DecisionProps {
   __v: number | null;
   createdAt: string | null;
   updatedAt: string | null;
+  group: GroupProps | null;
+  list: ListProps | null;
 }
 export interface UserProps {
   _id: string | null;

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -5,6 +5,7 @@ export interface OptionProps {
   customFields: string[];
   owner: string | null;
   createdAt: string | null;
+  image_url?: string | null;
   __v: number | null;
 }
 export interface ListProps {

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -28,7 +28,7 @@ export interface GroupProps {
 export interface DecisionProps {
   _id: string | null;
   votingStatus: string | null;
-  decisionsProcess_id: string | null;
+  decisionsProcess_id: string;
   completedAt: string | null;
   outcome: string | null;
   __v: number | null;

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -1,0 +1,45 @@
+export interface OptionProps {
+  _id: string | null;
+  name: string | null;
+  description: string | null;
+  customFields: string[];
+  owner: string | null;
+  createdAt: string | null;
+  __v: number | null;
+}
+export interface ListProps {
+  _id: string | null;
+  title: string | null;
+  description: string | null;
+  options: OptionProps[];
+  owner: string | null;
+  members: string[];
+  createdAt: string | null;
+  __v: number | null;
+}
+export interface GroupProps {
+  _id: string | null;
+  title: string | null;
+  description: string | null;
+  options: OptionProps[];
+  owner: string[];
+  members: string[];
+}
+export interface DecisionProps {
+  _id: string | null;
+  votingStatus: string | null;
+  decisionsProcess_id: string | null;
+  completedAt: string | null;
+  outcome: string | null;
+  __v: number | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+export interface UserProps {
+  _id: string | null;
+  username: string | null;
+  name: string | null;
+  email: string | null;
+  savedLists: Array<string> | null;
+  avatarImg?: string | null;
+}

--- a/utils/shuffleArray.js
+++ b/utils/shuffleArray.js
@@ -1,0 +1,7 @@
+export default function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const randomIndex = Math.floor(Math.random() * (i + 1));
+    [array[i], array[randomIndex]] = [array[randomIndex], array[i]];
+  }
+  return array;
+}


### PR DESCRIPTION
We (Dhiran and James) created a new file with all the type constructors named props.ts. We set up a new decision stack that takes the decision_id as a URL parameter and fetches all the information about the decision. If the decision process is this or that, then it takes you to make the this or that decision. Then we created a 'start decision' button which puts the decision in the database to have initialized save data, and status in progress. Then made the this or that buttons which get the current decision and eliminate the decision that wasn't picked by the user. This goes round until there is one option left and the decision status gets set to completed. This takes the user to the outcome page. We made it so that a user can view but not take action on someone else's go, and if you are on the page while someone makes a choice, it refreshes immediately. This was done through socket.io.